### PR TITLE
Switch to AsyncKeyedLock

### DIFF
--- a/PopApis/PopApis/PopApis.csproj
+++ b/PopApis/PopApis/PopApis.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AsyncKeyedLock" Version="6.0.5" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Core" Version="5.2.7" />
-    <PackageReference Include="KeyedSemaphores" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="5.0.9" />


### PR DESCRIPTION
Switched to AsyncKeyedLock offering better performance, scalability and correctness against rare race conditions, and optimized with pooling to further reduce allocations.